### PR TITLE
Fix SquaredDiff error function sum and avg computation

### DIFF
--- a/Algebra/src/main/java/cz/cvut/fel/ida/algebra/functions/specific/SquaredDiff.java
+++ b/Algebra/src/main/java/cz/cvut/fel/ida/algebra/functions/specific/SquaredDiff.java
@@ -19,11 +19,16 @@ public class SquaredDiff implements ErrorFcn {
             LOG.severe("Prediction output and target label are of different algebraic types! (e.g. scalar vs vector)");
         }
         Value diff = output.minus(target);
-        Value diffT = diff.clone();
-        diffT.transpose();
-        Value times = diff.times(diffT);
-//        return times.times(oneHalf);  //this is technically correct, but less interpretable
-        return times;
+
+        double accumulator = 0d;
+        int elements = 0;
+
+        for (double value : diff) {
+            accumulator += value * value;
+            elements += 1;
+        }
+
+        return new ScalarValue(accumulator / elements);
     }
 
     @Override

--- a/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/MatrixValue.java
+++ b/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/MatrixValue.java
@@ -70,13 +70,13 @@ public class MatrixValue extends Value {
 
         @Override
         public boolean hasNext() {
-            return row < maxRow || col < maxCol;
+            return row <= maxRow;
         }
 
         @Override
         public Double next() {
             double next = values[row][col];
-            if (col < cols - 1)
+            if (col < maxCol)
                 col++;
             else {
                 row++;


### PR DESCRIPTION
Hello,

this Pull Request fixes the wrong computation of the `SquaredDiff` function. Before those changes, the computation was dependent on the orientation of the `diff` vector - in some cases, `times` would be `VectorValue`, and in other cases, times would be `ScalarValue`.

There was also no averaging of the produced vector value.