### PR TITLE
Fix Windows GraphViz and paths construction

### DIFF
--- a/Drawing/src/main/java/cz/cvut/fel/ida/drawing/GraphViz.java
+++ b/Drawing/src/main/java/cz/cvut/fel/ida/drawing/GraphViz.java
@@ -99,7 +99,7 @@ public class GraphViz {
 
     private static String getGraphvizExecutable(Settings settings) {
         if (Settings.os == Settings.OS.WINDOWS) {
-            return Paths.get(settings.graphvizPathWindows, settings.graphVizAlgorithm + ".exe").toString();
+            return Paths.get(settings.graphVizAlgorithm + ".exe").toString();
         } else if (GraphViz.osName.contains("MacOSX")) {
             return Paths.get(settings.graphvizPathMac, settings.graphVizAlgorithm).toString();
         } else {

--- a/Drawing/src/main/java/cz/cvut/fel/ida/drawing/GraphViz.java
+++ b/Drawing/src/main/java/cz/cvut/fel/ida/drawing/GraphViz.java
@@ -4,6 +4,7 @@ import cz.cvut.fel.ida.setup.Settings;
 
 import java.awt.*;
 import java.io.*;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.logging.Logger;
@@ -98,11 +99,11 @@ public class GraphViz {
 
     private static String getGraphvizExecutable(Settings settings) {
         if (Settings.os == Settings.OS.WINDOWS) {
-            return settings.graphvizPathWindows + "/" + settings.graphVizAlgorithm + ".exe";
+            return Paths.get(settings.graphvizPathWindows, settings.graphVizAlgorithm + ".exe").toString();
         } else if (GraphViz.osName.contains("MacOSX")) {
-            return settings.graphvizPathMac + "/" + settings.graphVizAlgorithm;
+            return Paths.get(settings.graphvizPathMac, settings.graphVizAlgorithm).toString();
         } else {
-            return settings.graphvizPathLinux + "/" + settings.graphVizAlgorithm;
+            return Paths.get(settings.graphvizPathLinux, settings.graphVizAlgorithm).toString();
         }
     }
 
@@ -286,7 +287,7 @@ public class GraphViz {
      * @return Success: 1, Failure: -1
      */
     public int writeImageToFile(byte[] img, String file) {
-        File to = new File(tempDir + "/" + sanitize(file) + "." + imgtype);
+        File to = new File(Paths.get(tempDir, sanitize(file) + "." + imgtype).toString());
         return writeImageToFile(img, to);
     }
 

--- a/Settings/src/main/java/cz/cvut/fel/ida/setup/Settings.java
+++ b/Settings/src/main/java/cz/cvut/fel/ida/setup/Settings.java
@@ -150,7 +150,7 @@ public class Settings implements Serializable {
 
     public String graphvizPathLinux = "/usr/bin"; // this is where the dot typically is, if not, install graphviz
     public String graphvizPathMac = "/usr/local/bin";   //never tried OSX...
-    public String graphvizPathWindows = "../Resources/graphviz"; //get it if you  don't have it and want to use it!
+//    public String graphvizPathWindows = "../Resources/graphviz"; //get it if you  don't have it and want to use it!
 
     public String pythonPath = "/opt/miniconda3/envs/lrnn/bin/python";
 //    public String pythonPath = "python";

--- a/Settings/src/main/java/cz/cvut/fel/ida/setup/SourceFiles.java
+++ b/Settings/src/main/java/cz/cvut/fel/ida/setup/SourceFiles.java
@@ -240,7 +240,7 @@ public class SourceFiles extends Sources {
     }
 
     public static String sanitizeTempl(String name) {
-        String sane = name.replaceAll("[,:;'\\[\\]/]", "_");
+        String sane = name.replaceAll("[,;'\\[\\]/]", "_");
         return sane;
     }
 

--- a/Settings/src/main/java/cz/cvut/fel/ida/setup/SourceFiles.java
+++ b/Settings/src/main/java/cz/cvut/fel/ida/setup/SourceFiles.java
@@ -259,7 +259,7 @@ public class SourceFiles extends Sources {
     private String checkTemplate4Imports(Path path, AtomicBoolean changed, File foldDir) throws FileNotFoundException {
         try {
             if (path.toString().startsWith(".")) {
-                path = Paths.get(foldDir + "/" + path);
+                path = Paths.get(foldDir.toString(), path.toString());
             }
             List<String> strings = Files.readAllLines(path);
             for (int i = 0; i < strings.size(); i++) {


### PR DESCRIPTION
Hello,

This PR fixes paths problems on different platforms (Windows), which I discovered thanks to [this issue](https://github.com/LukasZahradnik/PyNeuraLogic/issues/32).

- Removed constructing paths via string concatenating (with `"/"` as separator)
- Removed `':'` from template path sanitizing (Caused paths like `C:\...` to be sanitized as `C_\...`)
- Calling `dot.exe` directly (for some reason, `dot.exe` was supposed to be in `Resources/graphviz`)

This PR is more focused on the Windows platform. There might be more issues related to macOS - it got [stuck on my tests](https://github.com/LukasZahradnik/PyNeuraLogic/actions/runs/2009074714) while trying to use graphviz to draw templates/samples in macOS.