### PR TITLE
Fix wrong indexing of MatrixValue class methods and Python samples evaluation

### DIFF
--- a/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/MatrixValue.java
+++ b/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/MatrixValue.java
@@ -161,17 +161,17 @@ public class MatrixValue extends Value {
 
     @Override
     public double get(int i) {
-        return values[i / rows][i % cols];
+        return values[i / cols][i % cols];
     }
 
     @Override
     public void set(int i, double value) {
-        values[i / rows][i % cols] = value;
+        values[i / cols][i % cols] = value;
     }
 
     @Override
     public void increment(int i, double value) {
-        values[i / rows][i % cols] += value;
+        values[i / cols][i % cols] += value;
     }
 
 

--- a/Neural/src/main/java/cz/cvut/fel/ida/neural/networks/computation/training/strategies/PythonTrainingStrategy.java
+++ b/Neural/src/main/java/cz/cvut/fel/ida/neural/networks/computation/training/strategies/PythonTrainingStrategy.java
@@ -114,22 +114,17 @@ public class PythonTrainingStrategy extends TrainingStrategy {
         });
     }
 
-    public PythonSampleBackpropagateLoss evaluateSample(NeuralSample sample) {
+    public String evaluateSample(NeuralSample sample) {
         trainer.invalidateSample(trainer.getInvalidation(), sample);
-        Result result = trainer.evaluateSample(trainer.getEvaluation(), sample);
-
-        return new PythonSampleBackpropagateLoss(sample, result);
+        return evaluation.evaluate(sample.query).toString(Settings.superDetailedNumberFormat);
     }
 
     public String evaluateSamples(List<NeuralSample> samples) {
         List<String> output = new ArrayList<>();
         NumberFormat format = Settings.superDetailedNumberFormat;
-        List<Result> results = listTrainer.evaluate(samples);
 
-        for (int i = 0, j = results.size(); i < j; ++i) {
-            Result result = results.get(i);
-
-            output.add(result.getOutput().toString(format));
+        for (int i = 0, j = samples.size(); i < j; ++i) {
+            output.add(evaluation.evaluate(samples.get(i).query).toString(format));
         }
 
         return output.toString();


### PR DESCRIPTION
This PR fixes:
- Wrong indexing of MatrixValue class methods (get, set, increment)
- Wrong evaluation of Python samples (test mode now returns the value directly without creating Result instances)