### PR TITLE
Implement minibatching for PythonTrainingStrategy

### DIFF
--- a/Learning/src/main/java/cz/cvut/fel/ida/learning/results/Result.java
+++ b/Learning/src/main/java/cz/cvut/fel/ida/learning/results/Result.java
@@ -33,9 +33,6 @@ public class Result implements Comparable<Result> {
         this.position = position;
         this.setTarget(target);
         this.setOutput(output);
-        if (!target.getClass().equals(output.getClass())) {
-            throw new ArithmeticException("Output and Target Value dimensions do not match!");
-        }
     }
 
     public Value errorValue() {


### PR DESCRIPTION
This PR implements mini batching for `PythonTrainingStrategy` by reusing `MiniBatchTrainer`.

It also fixes some issues in `MiniBatchTrainer`, such as:
- Wrong `IntStream` ranges (when the `sampleList` was shorter than `minibatchSize`, it crashed)
- Not properly using trainers in the `Task` class - threads were waiting on each (basically running sequentially) other because `learnFromSample` was called on parent `MiniBatchTrainer` instead of unique `SequentialTrainer`.