### PR TITLE
Minibatching run updates on one thread

### DIFF
--- a/Neural/src/main/java/cz/cvut/fel/ida/neural/networks/computation/iteration/actions/Backpropagation.java
+++ b/Neural/src/main/java/cz/cvut/fel/ida/neural/networks/computation/iteration/actions/Backpropagation.java
@@ -26,7 +26,7 @@ public class Backpropagation {
     private static final Logger LOG = Logger.getLogger(Backpropagation.class.getName());
     private final Settings settings;
 
-    WeightUpdater weightUpdater;
+    public WeightUpdater weightUpdater;
 
     /**
      * Backproper is a StateVisitor, takes care of the action taken during iteration

--- a/Neural/src/main/java/cz/cvut/fel/ida/neural/networks/computation/training/optimizers/Adam.java
+++ b/Neural/src/main/java/cz/cvut/fel/ida/neural/networks/computation/training/optimizers/Adam.java
@@ -5,7 +5,7 @@ import cz.cvut.fel.ida.algebra.values.Value;
 import cz.cvut.fel.ida.algebra.weights.Weight;
 import cz.cvut.fel.ida.setup.Settings;
 
-import java.util.List;
+import java.util.Collection;
 import java.util.logging.Logger;
 
 public class Adam implements Optimizer {
@@ -29,7 +29,7 @@ public class Adam implements Optimizer {
         this.epsilon = new ScalarValue(i_epsilon);
     }
 
-    public void performGradientStep(List<Weight> updatedWeights, Value[] gradients, int iteration) {
+    public void performGradientStep(Collection<Weight> updatedWeights, Value[] gradients, int iteration) {
         //correction
         final ScalarValue fix1 = new ScalarValue(1 / (1 - Math.pow(beta1.value, iteration)));
         final ScalarValue fix2 = new ScalarValue(1 / (1 - Math.pow(beta2.value, iteration)));

--- a/Neural/src/main/java/cz/cvut/fel/ida/neural/networks/computation/training/optimizers/Optimizer.java
+++ b/Neural/src/main/java/cz/cvut/fel/ida/neural/networks/computation/training/optimizers/Optimizer.java
@@ -6,7 +6,7 @@ import cz.cvut.fel.ida.neural.networks.computation.iteration.visitors.weights.We
 import cz.cvut.fel.ida.neural.networks.computation.training.NeuralModel;
 import cz.cvut.fel.ida.setup.Settings;
 
-import java.util.List;
+import java.util.Collection;
 
 public interface Optimizer {
 
@@ -32,7 +32,7 @@ public interface Optimizer {
      * @param gradients
      * @param iteration
      */
-    void performGradientStep(List<Weight> updatedWeights, Value[] gradients, int iteration);
+    void performGradientStep(Collection<Weight> updatedWeights, Value[] gradients, int iteration);
 
     void restart(Settings settings);
 }

--- a/Neural/src/main/java/cz/cvut/fel/ida/neural/networks/computation/training/optimizers/SGD.java
+++ b/Neural/src/main/java/cz/cvut/fel/ida/neural/networks/computation/training/optimizers/SGD.java
@@ -4,7 +4,7 @@ import cz.cvut.fel.ida.algebra.values.Value;
 import cz.cvut.fel.ida.algebra.weights.Weight;
 import cz.cvut.fel.ida.setup.Settings;
 
-import java.util.List;
+import java.util.Collection;
 import java.util.logging.Logger;
 
 public class SGD implements Optimizer {
@@ -17,7 +17,7 @@ public class SGD implements Optimizer {
     }
 
     @Override
-    public void performGradientStep(List<Weight> updatedWeights, Value[] gradients, int iteration) {
+    public void performGradientStep(Collection<Weight> updatedWeights, Value[] gradients, int iteration) {
         for (Weight updatedWeight : updatedWeights) {
             Value weightUpdate = gradients[updatedWeight.index].times(learningRate);
             updatedWeight.value.incrementBy(weightUpdate);


### PR DESCRIPTION
This PR modifies mini batching so that forward and back propagations are in parallel, but weight updates are running only on one thread - updates from all weight updaters are added together.

On my test case (clutrr 500 samples), this was about 3x faster than no mini batching. The previous mini batching was about 2x faster.

