### PR TITLE
Replace fact.toString with originalString in fact neuron creation

### DIFF
--- a/Neuralization/src/main/java/cz/cvut/fel/ida/neural/networks/structure/building/NeuronFactory.java
+++ b/Neuralization/src/main/java/cz/cvut/fel/ida/neural/networks/structure/building/NeuronFactory.java
@@ -138,7 +138,7 @@ public class NeuronFactory {
         FactNeuron result = neuronMaps.factNeurons.get(fact.literal);
         if (result == null) {    //fact neuron might have been created already and for them it is ok
             States.SimpleValue simpleValue = new States.SimpleValue(fact.getValue() == null ? this.defaultFactValue : fact.getValue());     //todo this is incompatible with ParentCounter state for Fact neurons...
-            FactNeuron factNeuron = new FactNeuron(fact.toString(), fact.weight, counter++, simpleValue);
+            FactNeuron factNeuron = new FactNeuron(fact.originalString, fact.weight, counter++, simpleValue);
             if (fact.weight != null && fact.weight.isLearnable()) {
                 factNeuron.hasLearnableValue = true;
                 simpleValue.isLearnable = true;


### PR DESCRIPTION
This PR changes the name of `FactNeuron` to the original string of the valued fact. This change is also projected into the sample drawing.

When a concrete value was assigned to the fact, it is be contained in the original string, thus visible in rendered images. 

When the weight is assigned to the fact in the form of dimensions, only the dimensions will be visible in rendered images. That's different from the previous implementation, where initial values of initialized weights would be in the name of valued facts.
Valued facts' values can still be visible in "Val:" under the name (although those are current values and not initials).
