### PR TITLE
Reimplement Adam optimizer to be more performant

### DIFF
--- a/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/MatrixValue.java
+++ b/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/MatrixValue.java
@@ -132,6 +132,16 @@ public class MatrixValue extends Value {
     }
 
     @Override
+    public double[] getAsArray() {
+        return values;
+    }
+
+    @Override
+    public void setAsArray(double[] value) {
+        this.values = value;
+    }
+
+    @Override
     public Value apply(DoubleUnaryOperator function) {
         final MatrixValue result = new MatrixValue(rows, cols);
         final double[] tmpValues = result.values;

--- a/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/One.java
+++ b/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/One.java
@@ -56,6 +56,16 @@ public class One extends Value {
     }
 
     @Override
+    public double[] getAsArray() {
+        return new double[]{one.value};
+    }
+
+    @Override
+    public void setAsArray(double[] value) {
+        LOG.warning("Trying to set value of constant ONE");
+    }
+
+    @Override
     public Value apply(DoubleUnaryOperator function) {
         throw new ArithmeticException("Trying to modify value of constant ONE");
     }

--- a/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/ScalarValue.java
+++ b/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/ScalarValue.java
@@ -89,6 +89,16 @@ public class ScalarValue extends Value {
     }
 
     @Override
+    public double[] getAsArray() {
+        return new double[]{value};
+    }
+
+    @Override
+    public void setAsArray(double[] value) {
+        this.value = value[0];
+    }
+
+    @Override
     public Value apply(DoubleUnaryOperator function) {
         return new ScalarValue(function.applyAsDouble(value));
     }

--- a/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/StringValue.java
+++ b/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/StringValue.java
@@ -59,6 +59,14 @@ public class StringValue extends Value {
     }
 
     @Override
+    public double[] getAsArray() {
+        return new double[0];
+    }
+
+    @Override
+    public void setAsArray(double[] value) {}
+
+    @Override
     public Value apply(DoubleUnaryOperator function) {
         return null;
     }

--- a/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/TensorValue.java
+++ b/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/TensorValue.java
@@ -63,6 +63,14 @@ public class TensorValue extends Value {
     }
 
     @Override
+    public double[] getAsArray() {
+        return new double[0];
+    }
+
+    @Override
+    public void setAsArray(double[] value) {}
+
+    @Override
     public TensorValue apply(DoubleUnaryOperator function) {
         throw new ArithmeticException("Higher dimension Tensor operations are not implemented yet");
     }

--- a/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/Value.java
+++ b/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/Value.java
@@ -70,6 +70,20 @@ public abstract class Value implements Iterable<Double>, Comparable<Value>, Seri
     public abstract int[] size();
 
     /**
+     * Get the value representation as double array
+     *
+     * @return
+     */
+    public abstract double[] getAsArray();
+
+    /**
+     * Set the value representation from double array
+     *
+     * @param value
+     */
+    public abstract void setAsArray(double[] value);
+
+    /**
      * Element-wise application of a given real function
      *
      * @param function

--- a/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/VectorValue.java
+++ b/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/VectorValue.java
@@ -134,6 +134,16 @@ public class VectorValue extends Value {
     }
 
     @Override
+    public double[] getAsArray() {
+        return values;
+    }
+
+    @Override
+    public void setAsArray(double[] value) {
+        this.values = value;
+    }
+
+    @Override
     public Value apply(DoubleUnaryOperator function) {
         VectorValue result = new VectorValue(values.length, rowOrientation);
         double[] resultValues = result.values;

--- a/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/Zero.java
+++ b/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/Zero.java
@@ -54,6 +54,16 @@ class Zero extends Value {
     }
 
     @Override
+    public double[] getAsArray() {
+        return new double[]{zero.value};
+    }
+
+    @Override
+    public void setAsArray(double[] value) {
+        LOG.warning("Trying to set value of constant ZERO");
+    }
+
+    @Override
     public Value apply(DoubleUnaryOperator function) {
         throw new ArithmeticException("Trying to modify value of constant ZERO");
     }

--- a/Neural/pom.xml
+++ b/Neural/pom.xml
@@ -29,6 +29,12 @@
             <artifactId>annotations</artifactId>
             <version>19.0.0</version>
         </dependency>
+        <dependency>
+            <groupId>io.github.gustiks</groupId>
+            <artifactId>Resources</artifactId>
+            <version>0.3.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 

--- a/Neural/src/test/java/cz/cvut/fel/ida/neural/networks/computation/training/optimizers/AdamOptimizerTest.java
+++ b/Neural/src/test/java/cz/cvut/fel/ida/neural/networks/computation/training/optimizers/AdamOptimizerTest.java
@@ -1,0 +1,63 @@
+package cz.cvut.fel.ida.neural.networks.computation.training.optimizers;
+
+import cz.cvut.fel.ida.algebra.values.ScalarValue;
+import cz.cvut.fel.ida.algebra.values.Value;
+import cz.cvut.fel.ida.algebra.weights.Weight;
+import cz.cvut.fel.ida.utils.generic.TestAnnotations;
+
+import java.util.*;
+import java.util.logging.Logger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class AdamOptimizerTest {
+    private static final Logger LOG = Logger.getLogger(AdamOptimizerTest.class.getName());
+
+    @TestAnnotations.Fast
+    public void testStepOnScalars() {
+        List<Weight> weights = new ArrayList<>();
+        Value[] gradients = new Value[]{
+                new ScalarValue(0.4), new ScalarValue(0.4), new ScalarValue(-0.17), new ScalarValue(-0.17),
+                new ScalarValue(0.4), new ScalarValue(0.4), new ScalarValue(-0.17), new ScalarValue(-0.17),
+        };
+
+        double[] expectedValues = new double[]{
+                -0.879000000025,
+                0.510999999975,
+                -0.5609999999411766,
+                -0.2609999999411765,
+                -0.8799423078496942,
+                0.5100576921503058,
+                -0.5600759355766955,
+                -0.26007593557669545,
+        };
+
+        double[][] weightParams = new double[][]{
+                new double[]{-0.88, 0, 0}, new double[]{0.51, 0, 0},
+                new double[]{-0.56, 0, 0}, new double[]{-0.26, 0, 0},
+                new double[]{-0.88, 0.017, 0.01}, new double[]{0.51, 0.017, 0.01},
+                new double[]{-0.56, 0.017, 0.01}, new double[]{-0.26, 0.017, 0.01},
+        };
+
+        for (int i = 0; i < expectedValues.length; i++) {
+            Weight weight = new Weight(i, "w", new ScalarValue(weightParams[i][0]), false, true);
+            weight.momentum = new ScalarValue(weightParams[i][1]);
+            weight.velocity = new ScalarValue(weightParams[i][2]);
+
+            weights.add(weight);
+        }
+
+        Adam optimizer = new Adam(new ScalarValue(0.001));
+        optimizer.performGradientStep(weights.subList(0, 4), gradients, 1);
+
+        for (int i = 0; i < 4; i++) {
+            assertEquals(expectedValues[i], ((ScalarValue) weights.get(i).value).value);
+        }
+
+        optimizer.performGradientStep(weights.subList(4, 8), gradients, 2);
+
+        for (int i = 4; i < 8; i++) {
+            assertEquals(expectedValues[i], ((ScalarValue) weights.get(i).value).value);
+        }
+    }
+}


### PR DESCRIPTION
This PR changes the implementation of the Adam optimizer so that it is faster - it avoids creating intermediate/redundant Value objects and multiple iterations over momentum/velocity/weight values.

I added a small test to compare the current (new) implementation's results against those from the previous one. Additionally, the Adam optimizer is indirectly tested in PyNeuraLogic against PyTorch as well (in LSTM, RNN, and GRU tests)