### PR TITLE
Implement Slice transformation function

### DIFF
--- a/Algebra/src/main/java/cz/cvut/fel/ida/algebra/functions/transformation/joint/Slice.java
+++ b/Algebra/src/main/java/cz/cvut/fel/ida/algebra/functions/transformation/joint/Slice.java
@@ -1,0 +1,121 @@
+package cz.cvut.fel.ida.algebra.functions.transformation.joint;
+
+import cz.cvut.fel.ida.algebra.functions.ActivationFcn;
+import cz.cvut.fel.ida.algebra.functions.Transformation;
+import cz.cvut.fel.ida.algebra.values.MatrixValue;
+import cz.cvut.fel.ida.algebra.values.Value;
+import cz.cvut.fel.ida.algebra.values.VectorValue;
+
+import java.util.Arrays;
+import java.util.logging.Logger;
+
+public class Slice implements Transformation {
+    private static final Logger LOG = Logger.getLogger(Slice.class.getName());
+
+    private final int[] cols;
+    private final int[] rows;
+
+    public Slice() {
+        cols = null;
+        rows = null;
+    }
+
+    public Slice(int[] rows, int[] cols) {
+        if (cols != null && cols.length != 2) {
+            String err = "Unsupported col slice: " + Arrays.toString(cols) + ". Expected exactly two elements.";
+            LOG.severe(err);
+            throw new ArithmeticException(err);
+        }
+
+        if (rows != null && rows.length != 2) {
+            String err = "Unsupported row slice: " + Arrays.toString(rows) + ". Expected exactly two elements.";
+            LOG.severe(err);
+            throw new ArithmeticException(err);
+        }
+
+        this.cols = cols;
+        this.rows = rows;
+    }
+
+    @Override
+    public ActivationFcn replaceWithSingleton() {
+        return null;
+    }
+
+    public Value evaluate(Value combinedInputs) {
+        return combinedInputs.slice(this.rows, this.cols);
+    }
+
+    public Value differentiate(Value combinedInputs) {
+        return null; // Shouldn't be called
+    }
+
+    @Override
+    public ActivationFcn.State getState(boolean singleInput) {
+        return new State(this);
+    }
+
+    public static class State extends Transformation.State {
+        private final Slice slice;
+
+        public State(Slice transformation) {
+            super(transformation);
+
+            slice = transformation;
+        }
+
+        @Override
+        public void invalidate() {
+            super.invalidate();
+        }
+
+        @Override
+        public Value evaluate() {
+            return slice.evaluate(input);
+        }
+
+        @Override
+        public void ingestTopGradient(Value topGradient) {
+            final int[] size = topGradient.size();
+
+            if (size.length == 0) {
+                processedGradient = topGradient;
+
+                return;
+            }
+
+            final int rowsTo = slice.rows == null ? size[0] : slice.rows[1];
+            final int rowsFrom = slice.rows == null ? 0 : slice.rows[0];
+
+            final int colsTo = slice.cols == null ? size[1] : slice.cols[1];
+            final int colsFrom = slice.cols == null ? 0 : slice.cols[0];
+
+            final double[] values = topGradient.getAsArray();
+            final double[] inputValues = input.getAsArray();
+            final double[] outputValues = new double[inputValues.length];
+
+            if (topGradient instanceof VectorValue) {
+                boolean orientation = ((VectorValue) topGradient).rowOrientation;
+
+                if (orientation) {
+                    System.arraycopy(values, 0, outputValues, colsFrom, values.length);
+                } else {
+                    System.arraycopy(values, 0, outputValues, rowsFrom, values.length);
+                }
+
+                processedGradient = new VectorValue(outputValues, orientation);
+                return;
+            }
+
+            final int rows = ((MatrixValue) input).rows;
+            final int cols = ((MatrixValue) input).cols;
+            final int colNum = colsTo - colsFrom;
+
+            for (int i = rowsFrom; i < rowsTo; i++) {
+                System.arraycopy(values, (i - rowsFrom) * colNum, outputValues, i * cols + colsFrom, colNum);
+            }
+
+            processedGradient = new MatrixValue(outputValues, rows, cols);
+        }
+    }
+}

--- a/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/MatrixValue.java
+++ b/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/MatrixValue.java
@@ -132,6 +132,38 @@ public class MatrixValue extends Value {
     }
 
     @Override
+    public Value slice(int[] rows, int[] cols) {
+        final int rowsTo = rows == null ? this.rows : rows[1];
+        final int rowsFrom = rows == null ? 0 : rows[0];
+
+        final int colsTo = cols == null ? this.cols : cols[1];
+        final int colsFrom = cols == null ? 0 : cols[0];
+
+        if (rowsFrom < 0 || rowsTo > this.rows || rowsFrom >= rowsTo) {
+            String err = "Cannot slice MatrixValue with size " + Arrays.toString(this.size()) + " with row slice " + Arrays.toString(rows);
+            LOG.severe(err);
+            throw new ArithmeticException(err);
+        }
+
+        if (colsFrom < 0 || colsTo > this.cols || colsFrom >= colsTo) {
+            String err = "Cannot slice MatrixValue with size " + Arrays.toString(this.size()) + " with col slice " + Arrays.toString(cols);
+            LOG.severe(err);
+            throw new ArithmeticException(err);
+        }
+
+        final int colNum = colsTo - colsFrom;
+        final int rowNum = rowsTo - rowsFrom;
+
+        final double[] resValues = new double[rowNum * colNum];
+
+        for (int i = rowsFrom; i < rowsTo; i++) {
+            System.arraycopy(values, i * this.cols + colsFrom, resValues, (i - rowsFrom) * colNum, colNum);
+        }
+
+        return new MatrixValue(resValues, rowNum, colNum);
+    }
+
+    @Override
     public double[] getAsArray() {
         return values;
     }

--- a/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/One.java
+++ b/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/One.java
@@ -56,6 +56,11 @@ public class One extends Value {
     }
 
     @Override
+    public Value slice(int[] rows, int[] cols) {
+        return this.one.slice(rows, cols);
+    }
+
+    @Override
     public double[] getAsArray() {
         return new double[]{one.value};
     }

--- a/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/ScalarValue.java
+++ b/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/ScalarValue.java
@@ -4,6 +4,7 @@ import cz.cvut.fel.ida.algebra.values.inits.ValueInitializer;
 import org.jetbrains.annotations.NotNull;
 
 import java.text.NumberFormat;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.function.DoubleUnaryOperator;
 import java.util.logging.Logger;
@@ -86,6 +87,23 @@ public class ScalarValue extends Value {
     @Override
     public int[] size() {
         return new int[0];
+    }
+
+    @Override
+    public Value slice(int[] rows, int[] cols) {
+        if (cols != null && (cols[0] != 0 || cols[1] != 1)) {
+            String err = "Cannot slice ScalarValue " + this + " with col slice " + Arrays.toString(cols);
+            LOG.severe(err);
+            throw new ArithmeticException(err);
+        }
+
+        if (rows != null && (rows[0] != 0 || rows[1] != 1)) {
+            String err = "Cannot slice ScalarValue " + this + " with row slice " + Arrays.toString(cols);
+            LOG.severe(err);
+            throw new ArithmeticException(err);
+        }
+
+        return new ScalarValue(value);
     }
 
     @Override

--- a/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/StringValue.java
+++ b/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/StringValue.java
@@ -59,6 +59,11 @@ public class StringValue extends Value {
     }
 
     @Override
+    public Value slice(int[] rows, int[] cols) {
+        return null;
+    }
+
+    @Override
     public double[] getAsArray() {
         return new double[0];
     }

--- a/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/TensorValue.java
+++ b/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/TensorValue.java
@@ -63,6 +63,11 @@ public class TensorValue extends Value {
     }
 
     @Override
+    public Value slice(int[] rows, int[] cols) {
+        return null;
+    }
+
+    @Override
     public double[] getAsArray() {
         return new double[0];
     }

--- a/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/Value.java
+++ b/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/Value.java
@@ -69,6 +69,14 @@ public abstract class Value implements Iterable<Double>, Comparable<Value>, Seri
      */
     public abstract int[] size();
 
+    /** Get a slice of the value
+     *
+     * @param rows
+     * @param cols
+     * @return
+     */
+    public abstract Value slice(int[] rows, int[] cols);
+
     /**
      * Get the value representation as double array
      *

--- a/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/VectorValue.java
+++ b/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/VectorValue.java
@@ -134,6 +134,47 @@ public class VectorValue extends Value {
     }
 
     @Override
+    public Value slice(int[] rows, int[] cols) {
+        int[] sliceCoords;
+
+        if (rowOrientation) {
+            if (rows != null && rows[0] != 0 && rows[1] != 1) {
+                String err = "Cannot slice VectorValue with size " + Arrays.toString(this.size()) + " with row slice " + Arrays.toString(rows);
+                LOG.severe(err);
+                throw new ArithmeticException(err);
+            }
+
+            sliceCoords = cols;
+        } else {
+            if (cols != null && cols[0] != 0 && cols[1] != 1) {
+                String err = "Cannot slice VectorValue with size " + Arrays.toString(this.size()) + " with col slice " + Arrays.toString(cols);
+                LOG.severe(err);
+                throw new ArithmeticException(err);
+            }
+
+            sliceCoords = rows;
+        }
+
+        if (sliceCoords == null) {
+            return new VectorValue(values, rowOrientation);
+        }
+
+        final int from = sliceCoords[0];
+        final int to = sliceCoords[1];
+
+        if (from < 0 || to > values.length || from >= to) {
+            String err = "Cannot slice VectorValue with size " + Arrays.toString(this.size()) + " with slice " + Arrays.toString(sliceCoords);
+            LOG.severe(err);
+            throw new ArithmeticException(err);
+        }
+
+        final double[] resValues = new double[to - from];
+        System.arraycopy(values, from, resValues, 0, resValues.length);
+
+        return new VectorValue(resValues, rowOrientation);
+    }
+
+    @Override
     public double[] getAsArray() {
         return values;
     }

--- a/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/Zero.java
+++ b/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/Zero.java
@@ -54,6 +54,11 @@ class Zero extends Value {
     }
 
     @Override
+    public Value slice(int[] rows, int[] cols) {
+        return this.zero.slice(rows, cols);
+    }
+
+    @Override
     public double[] getAsArray() {
         return new double[]{zero.value};
     }

--- a/Algebra/src/test/java/cz/cvut/fel/ida/algebra/functions/SliceTest.java
+++ b/Algebra/src/test/java/cz/cvut/fel/ida/algebra/functions/SliceTest.java
@@ -1,0 +1,83 @@
+package cz.cvut.fel.ida.algebra.functions;
+
+import cz.cvut.fel.ida.algebra.functions.transformation.joint.Slice;
+import cz.cvut.fel.ida.algebra.values.MatrixValue;
+import cz.cvut.fel.ida.algebra.values.ScalarValue;
+import cz.cvut.fel.ida.algebra.values.Value;
+import cz.cvut.fel.ida.algebra.values.VectorValue;
+import cz.cvut.fel.ida.utils.generic.TestAnnotations;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SliceTest {
+
+    @TestAnnotations.Fast
+    public void evalScalarValue() {
+        ScalarValue scalar = new ScalarValue(0.5);
+
+        Slice slice = new Slice();
+        Value eval = slice.evaluate(scalar);
+
+        assertEquals(eval.getClass(), ScalarValue.class);
+        assertArrayEquals(eval.getAsArray(), scalar.getAsArray());
+
+        slice = new Slice(new int[] {0, 1}, new int[] {0, 1});
+        eval = slice.evaluate(scalar);
+
+        assertEquals(eval.getClass(), ScalarValue.class);
+        assertArrayEquals(eval.getAsArray(), scalar.getAsArray());
+    }
+
+    @TestAnnotations.Fast
+    public void evalVectorValue() {
+        VectorValue vector = new VectorValue(new double[] {0.5, 1.5, 2.0, 2.5});
+
+        Slice slice = new Slice();
+        Value eval = slice.evaluate(vector);
+
+        assertEquals(eval.getClass(), VectorValue.class);
+        assertArrayEquals(eval.getAsArray(), vector.getAsArray());
+
+        slice = new Slice(new int[] {0, 1}, new int[] {0, 1});
+        eval = slice.evaluate(vector);
+
+        assertEquals(eval.getClass(), VectorValue.class);
+        assertArrayEquals(eval.getAsArray(), new double[] { 0.5 });
+
+        slice = new Slice(new int[] {1, 3}, new int[] {0, 1});
+        eval = slice.evaluate(vector);
+
+        assertEquals(eval.getClass(), VectorValue.class);
+        assertArrayEquals(eval.getAsArray(), new double[] { 1.5, 2.0 });
+    }
+
+    @TestAnnotations.Fast
+    public void evalMatrixValue() {
+        MatrixValue matrix = new MatrixValue(new double[] {0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0}, 2, 4);
+
+        Slice slice = new Slice();
+        Value eval = slice.evaluate(matrix);
+
+        assertEquals(eval.getClass(), MatrixValue.class);
+        assertArrayEquals(eval.getAsArray(), matrix.getAsArray());
+
+        slice = new Slice(new int[] {0, 1}, new int[] {0, 1});
+        eval = slice.evaluate(matrix);
+
+        assertEquals(eval.getClass(), MatrixValue.class);
+        assertArrayEquals(eval.getAsArray(), new double[] { 0.0 });
+
+        slice = new Slice(new int[] {1, 2}, null);
+        eval = slice.evaluate(matrix);
+
+        assertEquals(eval.getClass(), MatrixValue.class);
+        assertArrayEquals(eval.getAsArray(), new double[] { 4.0, 5.0, 6.0, 7.0 });
+
+        slice = new Slice(new int[] {1, 2}, new int[] {1, 3});
+        eval = slice.evaluate(matrix);
+
+        assertEquals(eval.getClass(), MatrixValue.class);
+        assertArrayEquals(eval.getAsArray(), new double[] { 5.0, 6.0 });
+    }
+}


### PR DESCRIPTION
This PR introduces a new transformation function for slicing values. It supports only the simplest slicing - it's defined only by two positive indices (start, end) for each axis.

Its use case is the following:
```java
 VectorValue vector = new VectorValue(new double[] {0.5, 1.5, 2.0, 2.5});

// can be also new Slice(new int[] {1, 3}, null);
Slice slice = new Slice(new int[] {1, 3}, new int[] {0, 1});
Value eval = slice.evaluate(vector);

// We selected second and third elements - {1, 3}
assertArrayEquals(eval.getAsArray(), new double[] { 1.5, 2.0 });
```

I haven't registered any singleton, as this is a parametrized transformation function, and handling of it will be implemented in Python (it's not supported for Java "native" files).

