### PR TITLE
Disable pruning of transformations that change shapes and implement reshape

### DIFF
--- a/Algebra/src/main/java/cz/cvut/fel/ida/algebra/functions/Transformation.java
+++ b/Algebra/src/main/java/cz/cvut/fel/ida/algebra/functions/Transformation.java
@@ -39,6 +39,15 @@ public interface Transformation extends ActivationFcn, Exportable {
      */
     public abstract Value differentiate(Value combinedInputs);
 
+    /**
+     * Checks whether the shape of the transformation function output value differs from the shape of its input value.
+     *
+     * @return
+     */
+    default boolean changesShape() {
+        return false;
+    }
+
     public static Transformation getFunction(Settings.TransformationFcn transformation) {
         ElementWise function = ElementWise.getFunction(transformation);
         if (function != null) {

--- a/Algebra/src/main/java/cz/cvut/fel/ida/algebra/functions/transformation/joint/Reshape.java
+++ b/Algebra/src/main/java/cz/cvut/fel/ida/algebra/functions/transformation/joint/Reshape.java
@@ -1,0 +1,90 @@
+package cz.cvut.fel.ida.algebra.functions.transformation.joint;
+
+import cz.cvut.fel.ida.algebra.functions.ActivationFcn;
+import cz.cvut.fel.ida.algebra.functions.Transformation;
+import cz.cvut.fel.ida.algebra.values.MatrixValue;
+import cz.cvut.fel.ida.algebra.values.ScalarValue;
+import cz.cvut.fel.ida.algebra.values.Value;
+import cz.cvut.fel.ida.algebra.values.VectorValue;
+
+import java.util.Arrays;
+import java.util.logging.Logger;
+
+public class Reshape implements Transformation {
+    private static final Logger LOG = Logger.getLogger(Reshape.class.getName());
+
+    private final int[] shape;
+
+    public Reshape(int[] shape) {
+        if (shape == null) {
+            shape = new int[] {0};
+        }
+
+        if (shape.length > 2) {
+            String err = "Unsupported shape: " + Arrays.toString(shape) + ". Expected max two elements.";
+            LOG.severe(err);
+            throw new ArithmeticException(err);
+        }
+
+        this.shape = shape;
+    }
+
+    @Override
+    public ActivationFcn replaceWithSingleton() {
+        return null;
+    }
+
+    public Value evaluate(Value combinedInputs) {
+        return combinedInputs.reshape(this.shape);
+    }
+
+    public Value differentiate(Value combinedInputs) {
+        return null; // Shouldn't be called
+    }
+
+    @Override
+    public ActivationFcn.State getState(boolean singleInput) {
+        return new State(this);
+    }
+
+    @Override
+    public boolean changesShape() {
+        return true;
+    }
+
+    public static class State extends Transformation.State {
+        private final Reshape reshape;
+
+        public State(Reshape transformation) {
+            super(transformation);
+
+            reshape = transformation;
+        }
+
+        @Override
+        public void invalidate() {
+            super.invalidate();
+        }
+
+        @Override
+        public Value evaluate() {
+            return reshape.evaluate(input);
+        }
+
+        @Override
+        public void ingestTopGradient(Value topGradient) {
+            if (input instanceof ScalarValue) {
+                processedGradient = topGradient.reshape(new int[] { 0 });
+            } else if (input instanceof VectorValue) {
+                VectorValue v = (VectorValue) input;
+                final int len = v.values.length;
+
+                processedGradient = topGradient.reshape(new int[] { v.rowOrientation ? len : 0, v.rowOrientation ? 0 : len});
+            } else if (input instanceof MatrixValue) {
+                MatrixValue m = (MatrixValue) input;
+
+                processedGradient = topGradient.reshape(new int[] { m.rows, m.cols });
+            }
+        }
+    }
+}

--- a/Algebra/src/main/java/cz/cvut/fel/ida/algebra/functions/transformation/joint/Slice.java
+++ b/Algebra/src/main/java/cz/cvut/fel/ida/algebra/functions/transformation/joint/Slice.java
@@ -55,6 +55,11 @@ public class Slice implements Transformation {
         return new State(this);
     }
 
+    @Override
+    public boolean changesShape() {
+        return true;
+    }
+
     public static class State extends Transformation.State {
         private final Slice slice;
 

--- a/Algebra/src/main/java/cz/cvut/fel/ida/algebra/functions/transformation/joint/Transposition.java
+++ b/Algebra/src/main/java/cz/cvut/fel/ida/algebra/functions/transformation/joint/Transposition.java
@@ -38,6 +38,11 @@ public class Transposition implements Transformation {
         return new State(Singletons.transposition);
     }
 
+    @Override
+    public boolean changesShape() {
+        return true;
+    }
+
     public static class State extends Transformation.State {
 
         public State(Transformation transformation) {

--- a/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/MatrixValue.java
+++ b/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/MatrixValue.java
@@ -164,6 +164,49 @@ public class MatrixValue extends Value {
     }
 
     @Override
+    public Value reshape(int[] shape) {
+        final double[] data = values;
+
+        if (values.length == 1 && shape.length == 1 && shape[0] == 0) {
+            return new ScalarValue(values[0]);
+        }
+
+        if (shape.length == 1 && shape[0] == data.length) {
+            return new VectorValue(data);
+        }
+
+        if (shape.length == 2) {
+            if (shape[0] == 1 && shape[1] == data.length) {
+                return new MatrixValue(data, 1, data.length);
+            }
+
+            if (shape[0] == data.length && shape[1] == 1) {
+                return new MatrixValue(data, data.length, 1);
+            }
+
+            if (shape[0] == 0 && shape[1] == 0 && data.length == 1) {
+                return new ScalarValue(data[0]);
+            }
+
+            if (shape[0] == 0 && shape[1] == data.length) {
+                return new VectorValue(data);
+            }
+
+            if (shape[0] == data.length && shape[1] == 0) {
+                return new VectorValue(data, true);
+            }
+
+            if (data.length / shape[1] == shape[0]) {
+                return new MatrixValue(data, shape[0], shape[1]);
+            }
+        }
+
+        String err = "Cannot reshape MatrixValue of shape " + Arrays.toString(this.size()) + " to shape " + Arrays.toString(shape);
+        LOG.severe(err);
+        throw new ArithmeticException(err);
+    }
+
+    @Override
     public double[] getAsArray() {
         return values;
     }

--- a/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/One.java
+++ b/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/One.java
@@ -61,6 +61,11 @@ public class One extends Value {
     }
 
     @Override
+    public Value reshape(int[] shape) {
+        return this.one.reshape(shape).clone();
+    }
+
+    @Override
     public double[] getAsArray() {
         return new double[]{one.value};
     }

--- a/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/ScalarValue.java
+++ b/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/ScalarValue.java
@@ -107,6 +107,37 @@ public class ScalarValue extends Value {
     }
 
     @Override
+    public Value reshape(int[] shape) {
+        if (shape.length == 1 && shape[0] == 0) {
+            return this;
+        }
+
+        double[] data = new double[] { value };
+
+        if (shape.length == 2) {
+            if (shape[0] == 0 && shape[1] == 0) {
+                return this;
+            }
+
+            if (shape[0] == 0 && shape[1] == 1) {
+                return new VectorValue(data, false);
+            }
+
+            if (shape[0] == 1 && shape[1] == 0) {
+                return new VectorValue(data);
+            }
+
+            if (shape[0] == 1 && shape[1] == 1) {
+                return new MatrixValue(data, 1, 1);
+            }
+        }
+
+        String err = "Cannot reshape ScalarValue " + this + " to shape " + Arrays.toString(shape);
+        LOG.severe(err);
+        throw new ArithmeticException(err);
+    }
+
+    @Override
     public double[] getAsArray() {
         return new double[]{value};
     }

--- a/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/StringValue.java
+++ b/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/StringValue.java
@@ -64,6 +64,11 @@ public class StringValue extends Value {
     }
 
     @Override
+    public Value reshape(int[] shape) {
+        return null;
+    }
+
+    @Override
     public double[] getAsArray() {
         return new double[0];
     }

--- a/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/TensorValue.java
+++ b/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/TensorValue.java
@@ -68,6 +68,11 @@ public class TensorValue extends Value {
     }
 
     @Override
+    public Value reshape(int[] shape) {
+        return null;
+    }
+
+    @Override
     public double[] getAsArray() {
         return new double[0];
     }

--- a/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/Value.java
+++ b/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/Value.java
@@ -77,6 +77,13 @@ public abstract class Value implements Iterable<Double>, Comparable<Value>, Seri
      */
     public abstract Value slice(int[] rows, int[] cols);
 
+    /** Reshapes the value
+     *
+     * @param shape
+     * @return
+     */
+    public abstract Value reshape(int[] shape);
+
     /**
      * Get the value representation as double array
      *

--- a/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/VectorValue.java
+++ b/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/VectorValue.java
@@ -175,6 +175,49 @@ public class VectorValue extends Value {
     }
 
     @Override
+    public Value reshape(int[] shape) {
+        final double[] data = values;
+
+        if (values.length == 1 && shape.length == 1 && shape[0] == 0) {
+            return new ScalarValue(values[0]);
+        }
+
+        if (shape.length == 1 && shape[0] == data.length) {
+            return new VectorValue(data);
+        }
+
+        if (shape.length == 2) {
+            if (shape[0] == 1 && shape[1] == data.length) {
+                return new MatrixValue(data, 1, data.length);
+            }
+
+            if (shape[0] == data.length && shape[1] == 1) {
+                return new MatrixValue(data, data.length, 1);
+            }
+
+            if (shape[0] == 0 && shape[1] == 0 && data.length == 1) {
+                return new ScalarValue(data[0]);
+            }
+
+            if (shape[0] == 0 && shape[1] == data.length) {
+                return new VectorValue(data);
+            }
+
+            if (shape[0] == data.length && shape[1] == 0) {
+                return new VectorValue(data, true);
+            }
+
+            if (data.length / shape[1] == shape[0]) {
+                return new MatrixValue(data, shape[0], shape[1]);
+            }
+        }
+
+        String err = "Cannot reshape VectorValue of shape " + Arrays.toString(this.size()) + " to shape " + Arrays.toString(shape);
+        LOG.severe(err);
+        throw new ArithmeticException(err);
+    }
+
+    @Override
     public double[] getAsArray() {
         return values;
     }

--- a/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/Zero.java
+++ b/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/Zero.java
@@ -59,6 +59,11 @@ class Zero extends Value {
     }
 
     @Override
+    public Value reshape(int[] shape) {
+        return this.zero.reshape(shape).clone();
+    }
+
+    @Override
     public double[] getAsArray() {
         return new double[]{zero.value};
     }

--- a/Algebra/src/test/java/cz/cvut/fel/ida/algebra/functions/ReshapeTest.java
+++ b/Algebra/src/test/java/cz/cvut/fel/ida/algebra/functions/ReshapeTest.java
@@ -1,0 +1,123 @@
+package cz.cvut.fel.ida.algebra.functions;
+
+import cz.cvut.fel.ida.algebra.functions.transformation.joint.Reshape;
+import cz.cvut.fel.ida.algebra.functions.transformation.joint.Slice;
+import cz.cvut.fel.ida.algebra.values.MatrixValue;
+import cz.cvut.fel.ida.algebra.values.ScalarValue;
+import cz.cvut.fel.ida.algebra.values.Value;
+import cz.cvut.fel.ida.algebra.values.VectorValue;
+import cz.cvut.fel.ida.utils.generic.TestAnnotations;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ReshapeTest {
+
+    @TestAnnotations.Fast
+    public void evalMatrixOneElementReshape() {
+        MatrixValue matrix = new MatrixValue(new double[] { 1.0 }, 1, 1);
+
+        Reshape reshape = new Reshape(new int[] { 0 });
+        Value eval = reshape.evaluate(matrix);
+
+        assertEquals(eval.getClass(), ScalarValue.class);
+        assertArrayEquals(eval.getAsArray(), matrix.getAsArray());
+
+        reshape = new Reshape(null);
+        eval = reshape.evaluate(matrix);
+
+        assertEquals(eval.getClass(), ScalarValue.class);
+        assertArrayEquals(eval.getAsArray(), matrix.getAsArray());
+
+        reshape = new Reshape(new int[] {0, 0});
+        eval = reshape.evaluate(matrix);
+
+        assertEquals(eval.getClass(), ScalarValue.class);
+        assertArrayEquals(eval.getAsArray(), matrix.getAsArray());
+
+        reshape = new Reshape(new int[] {0, 1});
+        eval = reshape.evaluate(matrix);
+
+        assertEquals(eval.getClass(), VectorValue.class);
+        assertArrayEquals(eval.getAsArray(), matrix.getAsArray());
+        assertFalse(((VectorValue) eval).rowOrientation);
+
+        reshape = new Reshape(new int[] {1, 0});
+        eval = reshape.evaluate(matrix);
+
+        assertEquals(eval.getClass(), VectorValue.class);
+        assertArrayEquals(eval.getAsArray(), matrix.getAsArray());
+        assertTrue(((VectorValue) eval).rowOrientation);
+    }
+
+
+    @TestAnnotations.Fast
+    public void evalMatrixReshape() {
+        MatrixValue matrix = new MatrixValue(new double[] { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 }, 2, 3);
+
+        Reshape reshape = new Reshape(new int[] { 3, 2 });
+        Value eval = reshape.evaluate(matrix);
+
+        assertEquals(eval.getClass(), MatrixValue.class);
+        assertArrayEquals(eval.getAsArray(), matrix.getAsArray());
+        assertEquals(((MatrixValue) eval).rows, 3);
+        assertEquals(((MatrixValue) eval).cols, 2);
+
+        reshape = new Reshape(new int[] { 1, 6 });
+        eval = reshape.evaluate(matrix);
+
+        assertEquals(eval.getClass(), MatrixValue.class);
+        assertArrayEquals(eval.getAsArray(), matrix.getAsArray());
+        assertEquals(((MatrixValue) eval).rows, 1);
+        assertEquals(((MatrixValue) eval).cols, 6);
+
+        reshape = new Reshape(new int[] { 6, 1 });
+        eval = reshape.evaluate(matrix);
+
+        assertEquals(eval.getClass(), MatrixValue.class);
+        assertArrayEquals(eval.getAsArray(), matrix.getAsArray());
+        assertEquals(((MatrixValue) eval).rows, 6);
+        assertEquals(((MatrixValue) eval).cols, 1);
+
+        reshape = new Reshape(new int[] { 0, 6 });
+        eval = reshape.evaluate(matrix);
+
+        assertEquals(eval.getClass(), VectorValue.class);
+        assertArrayEquals(eval.getAsArray(), matrix.getAsArray());
+        assertFalse(((VectorValue) eval).rowOrientation);
+    }
+
+    @TestAnnotations.Fast
+    public void evalVectorValueReshape() {
+        VectorValue vector = new VectorValue(new double[] {0.5, 1.5, 2.0, 2.5});
+
+        Reshape reshape = new Reshape(new int[] {2, 2});
+        Value eval = reshape.evaluate(vector);
+
+        assertEquals(eval.getClass(), MatrixValue.class);
+        assertArrayEquals(eval.getAsArray(), vector.getAsArray());
+        assertEquals(((MatrixValue) eval).rows, 2);
+        assertEquals(((MatrixValue) eval).cols, 2);
+
+        reshape = new Reshape(new int[] {1, 4});
+        eval = reshape.evaluate(vector);
+
+        assertEquals(eval.getClass(), MatrixValue.class);
+        assertArrayEquals(eval.getAsArray(), vector.getAsArray());
+        assertEquals(((MatrixValue) eval).rows, 1);
+        assertEquals(((MatrixValue) eval).cols, 4);
+
+        reshape = new Reshape(new int[] {0, 4});
+        eval = reshape.evaluate(vector);
+
+        assertEquals(eval.getClass(), VectorValue.class);
+        assertArrayEquals(eval.getAsArray(), vector.getAsArray());
+        assertFalse(((VectorValue) eval).rowOrientation);
+
+        reshape = new Reshape(new int[] {4, 0});
+        eval = reshape.evaluate(vector);
+
+        assertEquals(eval.getClass(), VectorValue.class);
+        assertArrayEquals(eval.getAsArray(), vector.getAsArray());
+        assertTrue(((VectorValue) eval).rowOrientation);
+    }
+}

--- a/Neural/src/main/java/cz/cvut/fel/ida/neural/networks/structure/transforming/LinearChainReducer.java
+++ b/Neural/src/main/java/cz/cvut/fel/ida/neural/networks/structure/transforming/LinearChainReducer.java
@@ -46,6 +46,10 @@ public class LinearChainReducer implements NetworkReducing {
             if (settings.pruneOnlyIdentities && !(neuron instanceof AggregationNeuron) && !(neuron.getTransformation() instanceof Identity)) {
                 continue;
             }
+            if (neuron.getTransformation() != null && neuron.getTransformation().changesShape()) {
+                continue;
+            }
+
             boolean pruned = prune(inet, neuron);
             if (pruned) {
                 prunings++;


### PR DESCRIPTION
This PR disables the pruning of neurons that have a transformation that changes the shape (the output shape is different from the input shape, such as transposition).

It also implements reshape transformation function that changes the shape (or type) of the input value.

Such as, `ScalarValue(0)` can be turned into `MatrixValue` via shape `[1, 1]` or into column `VectorValue` `[1]`/`[0, 1]` or row `VectorValue` `[1, 0]`.

Similarly, 2x3 `MatrixValue([[0, 1, 2], [3, 4, 5]])` can be turned into 3x2 `MatrixValue` via shape `[3, 2]`, into 1x6 Matrix via shape `[1, 6], into column `VectorVector` via `[0, 6]` and so on.

1x1 `MatrixValue` can be turned into `ScalarValue` via shape `[0]`/`[0, 0]` or into `VectorValue` via `[1]`, `[0, 1]` or `[1, 0]`.