### PR TITLE
Parametrize concat

### DIFF
--- a/Algebra/src/main/java/cz/cvut/fel/ida/algebra/functions/combination/Concatenation.java
+++ b/Algebra/src/main/java/cz/cvut/fel/ida/algebra/functions/combination/Concatenation.java
@@ -3,11 +3,13 @@ package cz.cvut.fel.ida.algebra.functions.combination;
 import cz.cvut.fel.ida.algebra.functions.ActivationFcn;
 import cz.cvut.fel.ida.algebra.functions.Aggregation;
 import cz.cvut.fel.ida.algebra.functions.Combination;
+import cz.cvut.fel.ida.algebra.values.MatrixValue;
 import cz.cvut.fel.ida.algebra.values.ScalarValue;
 import cz.cvut.fel.ida.algebra.values.Value;
 import cz.cvut.fel.ida.algebra.values.VectorValue;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.logging.Logger;
 
@@ -21,6 +23,22 @@ import java.util.logging.Logger;
 public class Concatenation implements Combination, Aggregation {
     private static final Logger LOG = Logger.getLogger(Concatenation.class.getName());
 
+    private final int axis;
+
+    public Concatenation() {
+        this.axis = -1; // axis -1 = flatten
+    }
+
+    public Concatenation(int axis) {
+        this.axis = axis;
+
+        if (axis != -1 && axis != 0) {
+            String err = "Unsupported concatenation axis: " + axis + ". Expected either -1 or 0.";
+            LOG.severe(err);
+            throw new ArithmeticException(err);
+        }
+    }
+
     @Override
     public Combination replaceWithSingleton() {
         return Combination.Singletons.concatenation;
@@ -29,12 +47,41 @@ public class Concatenation implements Combination, Aggregation {
     @Override
     public Value evaluate(List<Value> inputs) {
         List<Double> concat = new ArrayList<>();
+
+        if (axis == -1) {
+            for (Value input : inputs) {
+                for (Double val : input) {
+                    concat.add(val);
+                }
+            }
+
+            return new VectorValue(concat);
+        }
+
+        final int[] dimensions = inputs.get(0).size();
+        final int colSize = dimensions.length == 2 ? dimensions[1] : 1;
+
         for (Value input : inputs) {
+            final int[] valSize = input.size();
+
+            if ((valSize.length == 0 && colSize != 1) || (valSize.length == 2 && valSize[1] != colSize)) {
+                String err = "Cannot concatenate value with size: " + Arrays.toString(valSize) + ". Expected " + colSize + " columns.";
+                LOG.severe(err);
+                throw new ArithmeticException(err);
+            }
+
             for (Double val : input) {
                 concat.add(val);
             }
         }
-        return new VectorValue(concat);
+
+        double[] concatValues = concat.stream().mapToDouble(d -> d).toArray();
+
+        if (colSize == 1) {
+            return new VectorValue(concatValues, true);
+        }
+
+        return new MatrixValue(concatValues, concatValues.length / colSize, colSize);
     }
 
     @Override
@@ -67,18 +114,31 @@ public class Concatenation implements Combination, Aggregation {
 
     @Override
     public ActivationFcn.State getState(boolean singleInput) {
-        return new State(Combination.Singletons.concatenation);
+        return new State(this);
     }
 
     public static class State extends Combination.InputArrayState {
 
-        public State(Combination combination) {
+        Concatenation concatenation;
+
+        int processedIndex = 0;
+
+        public State(Concatenation combination) {
             super(combination);
+
+            this.concatenation = combination;
         }
 
         @Override
         public Value evaluate() {
-            return Combination.Singletons.concatenation.evaluate(accumulatedInputs);
+            return concatenation.evaluate(accumulatedInputs);
+        }
+
+        @Override
+        public void invalidate() {
+            super.invalidate();
+
+            processedIndex = 0;
         }
 
         @Override
@@ -93,7 +153,26 @@ public class Concatenation implements Combination, Aggregation {
          */
         @Override
         public Value nextInputGradient() {
-            return new ScalarValue(processedGradient.get(i++));
+            Value value = this.accumulatedInputs.get(i++);
+
+            if (value instanceof ScalarValue) {
+                return new ScalarValue(processedGradient.get(processedIndex++));
+            }
+
+            final int size = value.getAsArray().length;
+            final double[] slicedGradient = new double[size];
+
+            System.arraycopy(processedGradient.getAsArray(), processedIndex, slicedGradient, 0, size);
+            processedIndex += size;
+
+            if (value instanceof VectorValue) {
+                VectorValue v = (VectorValue) value;
+
+                return new VectorValue(slicedGradient, v.rowOrientation);
+            }
+
+            MatrixValue m = (MatrixValue) value;
+            return new MatrixValue(slicedGradient, m.rows, m.cols);
         }
     }
 }

--- a/Algebra/src/main/java/cz/cvut/fel/ida/algebra/functions/combination/Concatenation.java
+++ b/Algebra/src/main/java/cz/cvut/fel/ida/algebra/functions/combination/Concatenation.java
@@ -78,7 +78,7 @@ public class Concatenation implements Combination, Aggregation {
         double[] concatValues = concat.stream().mapToDouble(d -> d).toArray();
 
         if (colSize == 1) {
-            return new VectorValue(concatValues, true);
+            return new VectorValue(concatValues);
         }
 
         return new MatrixValue(concatValues, concatValues.length / colSize, colSize);

--- a/Algebra/src/test/java/cz/cvut/fel/ida/algebra/functions/ConcatenationTest.java
+++ b/Algebra/src/test/java/cz/cvut/fel/ida/algebra/functions/ConcatenationTest.java
@@ -1,6 +1,7 @@
 package cz.cvut.fel.ida.algebra.functions;
 
 import cz.cvut.fel.ida.algebra.functions.combination.Concatenation;
+import cz.cvut.fel.ida.algebra.values.MatrixValue;
 import cz.cvut.fel.ida.algebra.values.ScalarValue;
 import cz.cvut.fel.ida.algebra.values.Value;
 import cz.cvut.fel.ida.algebra.values.VectorValue;
@@ -9,6 +10,7 @@ import cz.cvut.fel.ida.utils.generic.TestAnnotations;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class ConcatenationTest {
@@ -38,17 +40,20 @@ class ConcatenationTest {
         double[] x1 = {0.1, 0.5, 0.7, -0.1, 0.2};
         double[] x2 = {0, 0.35, -2};
         ArrayList<Value> vals = new ArrayList<>();
+
         vals.add(new VectorValue(x1));
         vals.add(new VectorValue(x2));
+        vals.add(new ScalarValue(0.0));
 
 //        ReLu reLu = new ReLu();
         Concatenation.State concatState = new Concatenation.State(Combination.Singletons.concatenation);
+        concatState.accumulatedInputs = vals;
 
-        concatState.ingestTopGradient(new VectorValue(new double[8]));
+        concatState.ingestTopGradient(new VectorValue(new double[9]));
 
-        for (int i = 0; i < 8; i++) {
+        for (int i = 0; i < 3; i++) {
             Value scalar = concatState.nextInputGradient();
-            assertEquals(scalar.getClass(), ScalarValue.class);
+            assertEquals(scalar.getClass(), vals.get(i).getClass());
         }
 
         try {
@@ -56,7 +61,28 @@ class ConcatenationTest {
         } catch (Exception e){
             System.out.println("correct no more");
         }
+    }
 
+    @TestAnnotations.Fast
+    public void evalAxisZero() {
+        double[] x1 = {1, 2};
+        double[] x2 = {3, 4};
+        double[] x3 = {5, 6, 7, 8};
 
+        List<Value> vals = new ArrayList<>();
+        vals.add(new VectorValue(x1, true));
+        vals.add(new VectorValue(x2, true));
+        vals.add(new MatrixValue(x3, 2, 2));
+
+//        ReLu reLu = new ReLu();
+        Concatenation concat = new Concatenation(0);
+        Value evaluation = concat.evaluate(vals);
+
+        System.out.println(evaluation);
+
+        assertEquals(evaluation.getClass(), MatrixValue.class);
+        assertArrayEquals(evaluation.getAsArray(), new double[] {1, 2, 3, 4, 5, 6, 7, 8});
+        assertEquals(((MatrixValue) evaluation).rows, 4);
+        assertEquals(((MatrixValue) evaluation).cols, 2);
     }
 }


### PR DESCRIPTION
This PR parametrizes concatenation. Concatenation on `axis=-1` is equal to flattening the input into a vector (the same behavior as in the previous version).
Concatenation on `axis=`0 adds values to new rows. Concatenation on `axis=1` is not implemented (adding values to new columns).

Also, concatenation now should support more value types and not just scalars.