### PR TITLE
Fix recursive neuron creation of splittable rules

### DIFF
--- a/Neuralization/src/main/java/cz/cvut/fel/ida/neural/networks/structure/building/Neuralizer.java
+++ b/Neuralization/src/main/java/cz/cvut/fel/ida/neural/networks/structure/building/Neuralizer.java
@@ -253,7 +253,7 @@ public class Neuralizer implements Exportable {
             for (Map.Entry<GroundHeadRule, Collection<GroundRule>> entry : ruleMap.entrySet()) {
                 Aggregation aggregation = entry.getKey().weightedRule.getAggregationFcn();
 
-                if (aggregation != null && aggregation.isSplittable()) { // Process masked literal
+                if (!splittable && aggregation != null && aggregation.isSplittable()) { // Process masked literal
                     Literal maskedLiteral = entry.getKey().groundHead.maskTerms(aggregation.aggregableTerms());
                     recursiveNeuronsCreation(maskedLiteral, closedSet, neuronMaps, currentNeuralSets, true);
                     continue;


### PR DESCRIPTION
This PR fixes an oversight of not creating neurons of rules that have splittable aggregation.

This causes issues when we have literals in bodies that are heads of other rules. I was testing this functionality only with facts in bodies, which are handled differently.

For example, this usecase was broken:
```
template += (R.rl(V.X) <= R.xs(V.X)) | [F.identity]
template += R.rl / 1 | [F.identity]

template += (R.head(V.Y, V.X) <= (R.ws(V.Y), R.rl(V.X))) | [F.softmax_agg(agg_terms=[1]), F.identity]
```