### PR TITLE
Fix initialization of Normalization singleton

### DIFF
--- a/Algebra/src/main/java/cz/cvut/fel/ida/algebra/functions/Transformation.java
+++ b/Algebra/src/main/java/cz/cvut/fel/ida/algebra/functions/Transformation.java
@@ -73,7 +73,7 @@ public interface Transformation extends ActivationFcn, Exportable {
     public static class Singletons {
         public static Softmax softmax = new Softmax();
         public static Sparsemax sparsemax = new Sparsemax();
-        public static Normalization normalization;
+        public static Normalization normalization = new Normalization();
 
         public static Transposition transposition = new Transposition();
         public static Identity identity = new Identity();


### PR DESCRIPTION
This PR fixes the missing initialization of the Normalization transformation function. Because it was null, tanh (default transformation) was used instead.