### PR TITLE
Fix vector value equality

### DIFF
--- a/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/VectorValue.java
+++ b/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/VectorValue.java
@@ -905,9 +905,11 @@ public class VectorValue extends Value {
     @Override
     public boolean equals(Value obj) {
         if (obj instanceof VectorValue) {
-            if (Arrays.equals(values, ((VectorValue) obj).values)) {
-                return true;
+            if (rowOrientation != ((VectorValue) obj).rowOrientation) {
+                return false;
             }
+
+            return Arrays.equals(values, ((VectorValue) obj).values);
         }
         return false;
     }


### PR DESCRIPTION
This PR fixes the equality check of vector values. This fix is supposed to prevent IsoCompression from removing nodes that only transpose vector values.
