### PR TITLE
Fix removing elements from input iterator while removing back edge

### DIFF
--- a/Neural/src/main/java/cz/cvut/fel/ida/neural/networks/structure/components/types/TopologicNetwork.java
+++ b/Neural/src/main/java/cz/cvut/fel/ida/neural/networks/structure/components/types/TopologicNetwork.java
@@ -168,8 +168,9 @@ public class TopologicNetwork<N extends State.Neural.Structure> extends NeuralNe
                 while (inputNeurons.hasNext()){
                     inputWeights.next();
                     if (inputNeurons.next() == input){
-                        inputNeurons.remove();
                         inputWeights.remove();
+                        inputs.remove();
+                        return;
                     }
                 }
             } else {


### PR DESCRIPTION
This PR fixes an issue reported here: https://github.com/LukasZahradnik/PyNeuraLogic/issues/44

Removing items from an iterator that is being iterated over (in the topoSortRecursive method) is causing issues.

I assumed that there could be only one neuron we are looking for in inputs, so I put a return there. Not sure if that is correct.
