### PR TITLE
Fix GSON serialization

### DIFF
--- a/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/distributions/Distribution.java
+++ b/Algebra/src/main/java/cz/cvut/fel/ida/algebra/values/distributions/Distribution.java
@@ -10,7 +10,7 @@ public abstract class Distribution implements Exportable {
     private static final Logger LOG = Logger.getLogger(Distribution.class.getName());
 
     transient Settings setting;
-    Random rg;
+    transient Random rg;
     /**
      * this is either limit for uniform or STD for normal
      */

--- a/Settings/src/main/java/cz/cvut/fel/ida/setup/Sources.java
+++ b/Settings/src/main/java/cz/cvut/fel/ida/setup/Sources.java
@@ -1,9 +1,9 @@
 package cz.cvut.fel.ida.setup;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
+import com.google.gson.*;
 import org.apache.commons.cli.CommandLine;
 
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.Reader;
 import java.util.List;
@@ -255,8 +255,15 @@ public class Sources {
     }
 
     public String exportToJson() {
+        JsonSerializer<File> serializer = (file, type, jsonSerializationContext) -> {
+            JsonObject jsonFile = new JsonObject();
+            jsonFile.addProperty("path", file.getPath());
+            return jsonFile;
+        };
+
         Gson gson = new GsonBuilder()
                 .setPrettyPrinting()
+                .registerTypeAdapter(File.class, serializer)
                 .serializeSpecialFloatingPointValues()
                 .create();
         String json = gson.toJson(this);

--- a/Utilities/src/main/java/cz/cvut/fel/ida/utils/exporting/Exportable.java
+++ b/Utilities/src/main/java/cz/cvut/fel/ida/utils/exporting/Exportable.java
@@ -2,8 +2,11 @@ package cz.cvut.fel.ida.utils.exporting;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonSerializer;
 
 import java.io.Serializable;
+import java.time.Duration;
 
 public interface Exportable<I> extends Serializable {
 
@@ -12,8 +15,16 @@ public interface Exportable<I> extends Serializable {
     }
 
     default String exportToJson() {
+        JsonSerializer<Duration> durationJsonSerializer = (duration, type, jsonSerializationContext) -> {
+            JsonObject jsonDuration = new JsonObject();
+            jsonDuration.addProperty("seconds", duration.getSeconds());
+            jsonDuration.addProperty("nanos", duration.getNano());
+            return jsonDuration;
+        };
+
         Gson gson = new GsonBuilder()
                 .setPrettyPrinting()
+                .registerTypeAdapter(Duration.class, durationJsonSerializer)
                 .serializeSpecialFloatingPointValues()
                 .create();
         String json = gson.toJson(this);


### PR DESCRIPTION
This PR adds GSON serialization adapters for some types that couldn't be serialized otherwise on some specific JVMs. This might be related to https://github.com/LukasZahradnik/PyNeuraLogic/discussions/46

I removed the serialization of the random instance (when exporting `IterativeTrainingStrategy`) because there is no way to get the seed out of the random class (except for reflection). The seed should be part of the settings.