### PR TITLE
Add flag for computing topological depths of neurons before post-processing

### DIFF
--- a/Neural/src/main/java/cz/cvut/fel/ida/neural/networks/computation/iteration/modes/Topologic.java
+++ b/Neural/src/main/java/cz/cvut/fel/ida/neural/networks/computation/iteration/modes/Topologic.java
@@ -147,11 +147,8 @@ public class Topologic {
 
         @Override
         public boolean hasNext() {
-            if (i == 0) {
-                return true;
-            }
             return i < Topologic.this.network.allNeuronsTopologic.size() &&
-                    Topologic.this.network.allNeuronsTopologic.get(i - 1) != outputNeuron; //we need the output neuron to be processed, too!
+                    (i == 0 || Topologic.this.network.allNeuronsTopologic.get(i - 1) != outputNeuron); //we need the output neuron to be processed, too!
         }
 
         @Override

--- a/Neural/src/main/java/cz/cvut/fel/ida/neural/networks/structure/building/builders/StatesBuilder.java
+++ b/Neural/src/main/java/cz/cvut/fel/ida/neural/networks/structure/building/builders/StatesBuilder.java
@@ -58,7 +58,7 @@ public class StatesBuilder {
 
 
     /**
-     * Sets individual dropout rates and ALSO computes depth of each neuron (since this is the only place where it is necessary).
+     * Sets individual dropout rates
      *
      * @param detailedNetwork
      */
@@ -70,6 +70,20 @@ public class StatesBuilder {
                 neuron.layer = 1;
             }
             dropoutRateStrategy.setDropout(neuron);
+        }
+    }
+
+    /**
+     * Computes depth (layer index) of each neuron
+     *
+     * @param detailedNetwork
+     */
+    public void setupNeuronLayerIndices(DetailedNetwork<State.Neural.Structure> detailedNetwork) {
+        for (int i = detailedNetwork.allNeuronsTopologic.size() - 1; i > 0; i--) {
+            BaseNeuron<Neurons, State.Neural> neuron = detailedNetwork.allNeuronsTopologic.get(i);
+            if (neuron.layer == 0) {
+                neuron.layer = 1;
+            }
             Iterator<Neurons> inputs = detailedNetwork.getInputs(neuron);
             while (inputs.hasNext()) {
                 Neurons next = inputs.next();

--- a/Neural/src/main/java/cz/cvut/fel/ida/neural/networks/structure/components/neurons/BaseNeuron.java
+++ b/Neural/src/main/java/cz/cvut/fel/ida/neural/networks/structure/components/neurons/BaseNeuron.java
@@ -5,6 +5,7 @@ import cz.cvut.fel.ida.algebra.functions.Transformation;
 import cz.cvut.fel.ida.neural.networks.computation.iteration.NeuronVisiting;
 import cz.cvut.fel.ida.neural.networks.computation.iteration.visitors.neurons.NeuronVisitor;
 import cz.cvut.fel.ida.neural.networks.structure.components.neurons.states.State;
+import cz.cvut.fel.ida.neural.networks.structure.components.neurons.topology.TopologicalTraversalState;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -68,6 +69,11 @@ public abstract class BaseNeuron<T extends Neurons, S extends State.Neural> impl
      * Depth of this neuron. Might be useful e.g. for Dropout or some transformations. todo unused
      */
     public int layer;
+
+    /**
+     * Traversal state of topological sorting
+     */
+    private TopologicalTraversalState topoTraversalState = TopologicalTraversalState.DEFAULT;
 
     public BaseNeuron(int index, String id, S state) {
         this.index = index;
@@ -134,6 +140,16 @@ public abstract class BaseNeuron<T extends Neurons, S extends State.Neural> impl
     @Override
     public int getLayer() {
         return this.layer;
+    }
+
+    @Override
+    public void setTopoTraversalState(TopologicalTraversalState state) {
+        this.topoTraversalState = state;
+    }
+
+    @Override
+    public TopologicalTraversalState getTopoTraversalState() {
+        return this.topoTraversalState;
     }
 
     public void visit(NeuronVisitor.Weighted visitor) {

--- a/Neural/src/main/java/cz/cvut/fel/ida/neural/networks/structure/components/neurons/Neurons.java
+++ b/Neural/src/main/java/cz/cvut/fel/ida/neural/networks/structure/components/neurons/Neurons.java
@@ -5,6 +5,7 @@ import cz.cvut.fel.ida.algebra.functions.Transformation;
 import cz.cvut.fel.ida.neural.networks.computation.iteration.NeuronVisiting;
 import cz.cvut.fel.ida.neural.networks.computation.iteration.visitors.neurons.NeuronVisitor;
 import cz.cvut.fel.ida.neural.networks.structure.components.neurons.states.State;
+import cz.cvut.fel.ida.neural.networks.structure.components.neurons.topology.TopologicalTraversalState;
 import cz.cvut.fel.ida.utils.exporting.Exportable;
 
 import java.util.ArrayList;
@@ -40,6 +41,10 @@ public interface Neurons<T extends Neurons, S extends State.Neural> extends Expo
     void setLayer(int i);
 
     int getLayer();
+
+    void setTopoTraversalState(TopologicalTraversalState state);
+
+    TopologicalTraversalState getTopoTraversalState();
 
     State.Neural.Computation getComputationView(int index);
 }

--- a/Neural/src/main/java/cz/cvut/fel/ida/neural/networks/structure/components/neurons/topology/TopologicalTraversalState.java
+++ b/Neural/src/main/java/cz/cvut/fel/ida/neural/networks/structure/components/neurons/topology/TopologicalTraversalState.java
@@ -1,0 +1,5 @@
+package cz.cvut.fel.ida.neural.networks.structure.components.neurons.topology;
+
+public enum TopologicalTraversalState {
+	DEFAULT, OPEN, CLOSED;
+}

--- a/Neural/src/main/java/cz/cvut/fel/ida/neural/networks/structure/components/types/TopologicNetwork.java
+++ b/Neural/src/main/java/cz/cvut/fel/ida/neural/networks/structure/components/types/TopologicNetwork.java
@@ -13,6 +13,8 @@ import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import static cz.cvut.fel.ida.neural.networks.structure.components.neurons.topology.TopologicalTraversalState.*;
+
 /**
  * A class with an explicitly stored (topological) ordering of neurons.
  */
@@ -117,14 +119,10 @@ public class TopologicNetwork<N extends State.Neural.Structure> extends NeuralNe
 
         LinkedList<Neurons> topoList = new LinkedList<>();
 
-        static final int OPEN = 1;
-        static final int CLOSED = -1;
-        static final int DEFAULT = 0;
-
         public List<BaseNeuron<Neurons, State.Neural>> topologicSort(List<? extends Neurons> startNeurons) {
 
             for (Neurons neuron : startNeurons) {
-                if (neuron.getLayer() == DEFAULT) {  // it should never be OPEN here...
+                if (neuron.getTopoTraversalState() == DEFAULT) {  // it should never be OPEN here...
                     topoSortRecursive(neuron);
                 }
             }
@@ -134,20 +132,20 @@ public class TopologicNetwork<N extends State.Neural.Structure> extends NeuralNe
             Iterator<Neurons> descendingIterator = topoList.descendingIterator();
             while (descendingIterator.hasNext()) {
                 BaseNeuron<Neurons, State.Neural> next = (BaseNeuron<Neurons, State.Neural>) descendingIterator.next();
-                next.setLayer(DEFAULT);
+                next.setTopoTraversalState(DEFAULT);
                 reverse.add(next);
             }
             return reverse;
         }
 
         private void topoSortRecursive(Neurons neuron) {
-            neuron.setLayer(OPEN);
+            neuron.setTopoTraversalState(OPEN);
 
             Iterator<Neurons> inputs = getInputs(neuron);
             while (inputs.hasNext()) {
                 Neurons input = inputs.next();
-                if (input.getLayer() != OPEN) {
-                    if (input.getLayer() != CLOSED) {
+                if (input.getTopoTraversalState() != OPEN) {
+                    if (input.getTopoTraversalState() != CLOSED) {
                         topoSortRecursive(input);
                     }
                 } else {
@@ -156,7 +154,7 @@ public class TopologicNetwork<N extends State.Neural.Structure> extends NeuralNe
                 }
             }
 
-            neuron.setLayer(CLOSED);
+            neuron.setTopoTraversalState(CLOSED);
             topoList.addFirst(neuron);
         }
 

--- a/Neuralization/src/main/java/cz/cvut/fel/ida/neural/networks/structure/building/NeuralNetBuilder.java
+++ b/Neuralization/src/main/java/cz/cvut/fel/ida/neural/networks/structure/building/NeuralNetBuilder.java
@@ -304,6 +304,10 @@ public class NeuralNetBuilder {
             statesBuilder.setupDropoutStates(neuralNetwork);  //setup individual dropout rates for each neuron
         }
 
+        if (settings.dropoutRate > 0 || settings.computeNeuronLayerIndices) {
+            statesBuilder.setupNeuronLayerIndices(neuralNetwork);
+        }
+
         if (getNeuronMaps().containsMasking) {
             neuralNetwork.containsInputMasking = true;
         }

--- a/Settings/src/main/java/cz/cvut/fel/ida/setup/Settings.java
+++ b/Settings/src/main/java/cz/cvut/fel/ida/setup/Settings.java
@@ -675,6 +675,8 @@ public class Settings implements Serializable {
 
     public double dropoutRate = 0.0;    //todo test
 
+    public boolean computeNeuronLayerIndices = false;
+
     private OptimizerSet optimizer = OptimizerSet.ADAM;
 
     public enum OptimizerSet {


### PR DESCRIPTION
Added an optional flag (disabled by default) that allows computing topological depths of neurons even without dropout enabled.

Found (and fixed) a bug that when the depth computation is run, ISO value compression then fails.